### PR TITLE
Replace aarch64 with arm64

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -38,7 +38,7 @@ download_release() {
 	version="$1"
 	filename="$2"
 	local platform=$(uname | sed 's/Darwin/macOS/')
-	local architecture=$(uname -m | tr '[:upper:]' '[:lower:]')
+	local architecture=$(uname -m | tr '[:upper:]' '[:lower:]' | sed -e s/aarch64/arm64/)
 	url="$GH_REPO/releases/download/v${version}/regula_${version}_${platform}_${architecture}.tar.gz"
 
 	echo "* Downloading $TOOL_NAME release $version... to $filename from $url"


### PR DESCRIPTION
Regula denotes ARM packages with arm64, like so:

[regula_3.2.1_Linux_arm64.tar.gz](https://github.com/fugue/regula/releases/download/v3.2.1/regula_3.2.1_Linux_arm64.tar.gz)

Replaces `aarch64` with `arm64` for compatibility on systems that report `aarch64` from `uname -m`.